### PR TITLE
some cleanups

### DIFF
--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -33,9 +33,8 @@ RUN buildDeps=" \
     && phpModules=" \
         bcmath bz2 calendar dba enchant exif ftp gd gettext gmp imap intl ldap mbstring mcrypt mssql mysql mysqli opcache pcntl pdo pdo_dblib pdo_mysql pdo_pgsql pgsql pspell shmop snmp soap sockets sysvmsg sysvsem sysvshm tidy wddx xmlrpc xsl zip xdebug \
     " \
-    && echo "deb http://httpredir.debian.org/debian jessie contrib non-free" > /etc/apt/sources.list.d/additional.list \
-    && apt-get update && apt-get install -y libc-client2007e libenchant1c2a libfreetype6 libicu52 libjpeg62-turbo libmcrypt4 libpng12-0 libpq5 libsybdb5 libtidy-0.99-0 libx11-6 libxpm4 libxslt1.1 snmp --no-install-recommends \
-    && apt-get install -y $buildDeps --no-install-recommends \
+    && apt-get update && apt-get install -y --no-install-recommends libc-client2007e libenchant1c2a libfreetype6 libicu52 libjpeg62-turbo libmcrypt4 libpng12-0 libpq5 libsybdb5 libtidy-0.99-0 libx11-6 libxpm4 libxslt1.1 snmp \
+    && apt-get install -y --no-install-recommends $buildDeps \
     && docker-php-source extract \
     && cd /usr/src/php/ext/ \
     && curl -L http://xdebug.org/files/xdebug-$XDEBUG_VERSION.tgz | tar -zxf - \
@@ -65,28 +64,21 @@ RUN buildDeps=" \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
 
 # Install additional packages
-RUN apt-get update && apt-get install -y git msmtp-mta openssh-client --no-install-recommends && rm -r /var/lib/apt/lists/*
+RUN apt-get install -y --no-install-recommends git msmtp-mta openssh-client rsync
 
 # Install composer and put binary into $PATH
-RUN curl -sS https://getcomposer.org/installer | php \
-    && mv composer.phar /usr/local/bin/ \
-    && ln -s /usr/local/bin/composer.phar /usr/local/bin/composer
+RUN curl -sSLo /usr/local/bin/composer https://getcomposer.org/download/1.4.2/composer.phar \
+    && chmod 755 /usr/local/bin/composer
 
 # Install phpunit and put binary into $PATH
-RUN curl -sSLo phpunit.phar https://phar.phpunit.de/phpunit-5.7.phar \
-    && chmod 755 phpunit.phar \
-    && mv phpunit.phar /usr/local/bin/ \
-    && ln -s /usr/local/bin/phpunit.phar /usr/local/bin/phpunit
+RUN curl -sSLo /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar \
+    && chmod 755 /usr/local/bin/phpunit
 
 # Install PHP Code sniffer
-RUN curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar \
-    && chmod 755 phpcs.phar \
-    && mv phpcs.phar /usr/local/bin/ \
-    && ln -s /usr/local/bin/phpcs.phar /usr/local/bin/phpcs \
-    && curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar \
-    && chmod 755 phpcbf.phar \
-    && mv phpcbf.phar /usr/local/bin/ \
-    && ln -s /usr/local/bin/phpcbf.phar /usr/local/bin/phpcbf
+RUN curl -sSLo /usr/local/bin/phpcs https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar \
+    && chmod 755 /usr/local/bin/phpcs
+    && curl -sSLo /usr/local/bin/phpcbf https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar \
+    && chmod 755 /usr/local/bin/phpcbf
 
 # Install Node.js
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
@@ -96,8 +88,6 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update && apt-get install yarn
-
-RUN apt-get install -y rsync
 
 RUN rm -r /var/lib/apt/lists/*
 


### PR DESCRIPTION
* remove duplicated source httpredir.debian.org/debian. In Jessie, /etc/apt/sources.list is already configure
* All of the needed packages are part of main, no need for contrib or non-free
* put the `--no-install-recommends` flag at the beginning of the cmdline
* download .phar files from https sources with clear and explicit versions rather than executing "arbitrary" command-line code as root
* avoid useless symlinks inside /usr/local/bin/
* download rsync alongside git msmtp-mta and openssh-client